### PR TITLE
KS test updates in TTO_analysis function

### DIFF
--- a/R/time_to_onset_analysis.R
+++ b/R/time_to_onset_analysis.R
@@ -120,9 +120,12 @@ time_to_onset_analysis <- function(
   results <- results[, nD_E := map2(primaryid_event, primaryid_substance, \(x, y) !x %in% y)]
   results <- results[, nD_E := map2(ttos_event, nD_E, \(x, y) x[y])]
   #### Calculate KS
+  results <- results[lengths(D_E)>0]
+  results <- results[lengths(nD_E)>0]
   results <- results[, ks_event := map2(D_E, nD_E, \(x, y) ks.test(unlist(x), unlist(y),
     alternative = "two.sided", exact = FALSE
   ))]
+  results <- results[lengths(D_nE)>0]
   results <- results[, ks_drug := map2(D_E, D_nE, \(x, y) ks.test(unlist(x), unlist(y),
     alternative = "two.sided", exact = FALSE
   ))]


### PR DESCRIPTION
KS test dind't work if at least one among D_E, D_nE, and nD_E was empty. Added a check before KS test. If one of this is empty the row drug-event is removed. KS test still performed for few observations.
@fusarolimichele still not merged in the main fork. Please check. 